### PR TITLE
Restrict spell checking to comments only.

### DIFF
--- a/syntax/squirrel.vim
+++ b/syntax/squirrel.vim
@@ -26,8 +26,8 @@ syn region squirrelString start=+@"+ skip=+\\"+ end=+"+ oneline
 syn region squirrelString start=+@" + skip=+\\"+ end=+ "+ contains=squirrelEscape
 
 " Comments
-syn region squirrelComment start="/\*" end="\*/"
-syn match squirrelComment "//.\{-}\(?>\|$\)\@="
+syn region squirrelComment start="/\*" end="\*/" contains=@Spell
+syn match squirrelComment "//.\{-}\(?>\|$\)\@=" contains=@Spell
 
 " Numbers
 syn match squirrelNumber "-\=\<\d\+\>"


### PR DESCRIPTION
This PR adds a minor fix to the syntax file so spell checking is limited only to comments, and does not happen on keywords or variable names.
